### PR TITLE
Remove Python 3.6 Support

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         architecture: [x86, x64]
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         architecture: [x86, x64]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setuptools.setup(
         "Environment :: Win32 (MS Windows)",
         "License :: OSI Approved :: MIT License",
         "Operating System :: Microsoft :: Windows",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -56,7 +55,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.11",
         "Topic :: Games/Entertainment :: Simulation"
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     setup_requires=["wheel"],
     ext_modules=[setuptools.Extension(
         name="pyuipc",


### PR DESCRIPTION
Python 3.6 ended support on December 23, 2021.