### PR TITLE
Add Python 3.12 pre-release to CI build

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         architecture: [x86, x64]
 
     steps:

--- a/src/UIPC_SDK_Python/pyuipc.cc
+++ b/src/UIPC_SDK_Python/pyuipc.cc
@@ -776,7 +776,7 @@ PreparedData::PreparedData(PyObject* list, bool forRead) :
         const TypeInfo* typeInfo = 0;
 #if PY_MAJOR_VERSION>=3
         if (PyUnicode_Check(type)) {
-            if (PyUnicode_GET_SIZE(type)!=1) {
+            if (PyUnicode_GET_LENGTH(type)!=1) {
 #else
         if (PyString_Check(type)) {
             if (PyString_GET_SIZE(type)!=1) {


### PR DESCRIPTION
Don't want any surprises when 3.12 is officially released.